### PR TITLE
add support for files

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -19,13 +19,11 @@ const link = (directories, cwd = process.cwd()) => {
           throw err;
         }
 
-        if (stats.isFile()) {
-          fs.symlinkSync(src, dist, 'file');
-        }
+        const type = stats.isFile() ?
+          'file' : stats.isDirectory() ?
+          'dir' : null;
 
-        if (stats.isDirectory()) {
-          fs.symlinkSync(src, dist, 'dir');
-        }
+        fs.symlinkSync(src, dist, type);
 
       });
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -10,7 +10,22 @@ const link = (directories, cwd = process.cwd()) => {
 
     fs.exists(dist, (exists) => {
       if (exists) { return; }
-      fs.symlinkSync(src, dist, 'dir');
+
+      fs.stat(cwdSrc, (err, stats) => {
+        if (err && err.code === 'ENOENT') {
+          return;
+        }
+
+        if (stats.isFile()) {
+          fs.symlinkSync(src, dist, 'file');
+        }
+
+        if (stats.isDirectory()) {
+          fs.symlinkSync(src, dist, 'dir');
+        }
+
+      });
+
     });
   });
 };

--- a/lib/link.js
+++ b/lib/link.js
@@ -19,14 +19,7 @@ const link = (directories, cwd = process.cwd()) => {
           throw err;
         }
 
-        const type = stats.isFile() ?
-          'file' : stats.isDirectory() ?
-          'dir' : null;
-
-        if (!type) {
-          throw new Error('Unknown entry type');
-        }
-
+        const type = getTypeByStats(stats);
         fs.symlinkSync(src, dist, type);
 
       });
@@ -34,5 +27,17 @@ const link = (directories, cwd = process.cwd()) => {
     });
   });
 };
+
+function getTypeByStats(stats) {
+  if (stats.isFile()) {
+    return 'file';
+  }
+
+  if (stats.isDirectory()) {
+    return 'dir';
+  }
+
+  throw new Error('Unknown entry type');
+}
 
 module.exports = link;

--- a/lib/link.js
+++ b/lib/link.js
@@ -23,6 +23,10 @@ const link = (directories, cwd = process.cwd()) => {
           'file' : stats.isDirectory() ?
           'dir' : null;
 
+        if (!type) {
+          throw new Error('Unknown entry type');
+        }
+
         fs.symlinkSync(src, dist, type);
 
       });

--- a/lib/link.js
+++ b/lib/link.js
@@ -12,8 +12,11 @@ const link = (directories, cwd = process.cwd()) => {
       if (exists) { return; }
 
       fs.stat(cwdSrc, (err, stats) => {
-        if (err && err.code === 'ENOENT') {
-          return;
+        if (err) {
+          if (err.code === 'ENOENT') {
+            throw new Error(`No entry: ${cwdSrc}`);
+          }
+          throw err;
         }
 
         if (stats.isFile()) {


### PR DESCRIPTION
add support if you have a single file instead of a folder

"requireSymlinks": {
    "somedir": "./somedir",
    "app": "./app.js"
  },
